### PR TITLE
Disable sailjail sandbox for harbour-defender program. Fixes #5.

### DIFF
--- a/harbour-defender.desktop
+++ b/harbour-defender.desktop
@@ -10,3 +10,6 @@ Name=Defender
 # Remember to comment out the following line, if you do not want to use
 # a different app name in German locale (de).
 #Name[de]=Abwehrer
+
+[X-Sailjail]
+Sandboxing=Disabled


### PR DESCRIPTION
This is needed for the GUI to work on Sailfish 4.4.x.