### PR TITLE
Support SFOS Community port

### DIFF
--- a/harbour-defender-adRestart.path
+++ b/harbour-defender-adRestart.path
@@ -3,6 +3,8 @@ Description=Restart Aliendalvik service whenever requested from Defender
 Documentation= man:systemd.path
 #user units do NOT work for system: After=pre-user-session.target
 After=sailfish-unlock-agent.service
+After=decrypt-home_encrypted.service
+DefaultDependencies=no
 
 [Path]
 PathExists=/home/nemo/.config/harbour-defender/adRestart

--- a/harbour-defender-updLoop.path
+++ b/harbour-defender-updLoop.path
@@ -3,6 +3,8 @@ Description=Check for update loop and break it whenever requested from Defender
 Documentation= man:systemd.path
 #user units do NOT work for system: After=pre-user-session.target
 After=sailfish-unlock-agent.service
+After=decrypt-home_encrypted.service
+DefaultDependencies=no
 
 [Path]
 PathExists=/home/nemo/.config/harbour-defender/updLoop

--- a/harbour-defender.path
+++ b/harbour-defender.path
@@ -3,6 +3,8 @@ Description=Run Defender updater whenever requested
 Documentation= man:systemd.path
 #user units do NOT work for system: After=pre-user-session.target
 After=sailfish-unlock-agent.service
+After=decrypt-home_encrypted.service
+DefaultDependencies=no
 
 [Path]
 PathExists=/home/nemo/.config/harbour-defender/update


### PR DESCRIPTION
- fixes issue #8  :
  - cyclic dependency in base.target that causes paths.target to be removed
  - `DefaultDependencies=no` remove the implicit `After=` in paths.target
- the community encryption unlocker is a different service (decrypt-home_encrypted.service)