### PR TITLE
Fixed translations

### DIFF
--- a/qml/pages/CookiesPage.qml
+++ b/qml/pages/CookiesPage.qml
@@ -11,7 +11,7 @@ Page {
         anchors.fill: parent
         header: SearchField {
             width: parent.width
-            placeholderText: "Search cookies"
+            placeholderText: qsTr("Search cookies")
             validator: RegExpValidator { regExp: /[0-9A-Za-z]+/ }
 
             EnterKey.onClicked: {
@@ -108,7 +108,7 @@ Page {
                         id: contextMenu
                         ContextMenu {
                             MenuItem {
-                                text: "Remove"
+                                text: qsTr("Remove")
                                 onClicked: remove()
                             }
                             MenuItem {

--- a/qml/pages/DocsPage.qml
+++ b/qml/pages/DocsPage.qml
@@ -46,7 +46,7 @@ Page {
             Label {
                 x: Theme.paddingLarge
                 width: parent.width - 2*x
-                text: qsTr("You can add custom lists by editing the file /etc/"+appName.toLowerCase()+".conf as root (either using the command line or an appropriate editor). See other sections in the config file for inspiration. In the square brackets [] should be a unique id.")
+                text: qsTr("You can add custom lists by editing the file /etc/defender.conf as root (either using the command line or an appropriate editor). See other sections in the config file for inspiration. In the square brackets [] should be a unique id.")
                 color: Theme.primaryColor
                 wrapMode: Text.Wrap
                 font.pixelSize: Theme.fontSizeMedium
@@ -90,7 +90,7 @@ Page {
             Label {
                 x: Theme.paddingLarge
                 width: parent.width - 2*x
-                text: qsTr("The cookie manager works by editing the $HOME/.local/share/org.sailfishos/browser/.mozilla/ (for SFOS<=3.4: $HOME/.mozilla/mozembed/) cookies.sqlite database. In order to access/work with cookies the browser needs to be closed before opening the cookies section, else you might see an empty window. All changes need the browser to be closed/restarted in order to take effect.")
+                text: qsTr("The cookie manager works by editing the -/.local/share/org.sailfishos/browser/.mozilla/ (for SFOS up to 3.4: -/.mozilla/mozembed/) cookies.sqlite database. In order to access/work with cookies the browser needs to be closed before opening the cookies section, else you might see an empty window. All changes need the browser to be closed/restarted in order to take effect.")
                 color: Theme.primaryColor
                 wrapMode: Text.Wrap
                 font.pixelSize: Theme.fontSizeMedium

--- a/qml/pages/WelcomePage.qml
+++ b/qml/pages/WelcomePage.qml
@@ -24,26 +24,26 @@ Page {
     ListModel {
         id: menuModel
         ListElement {
-            name: "Adblock Lists"
+            name: qsTr("Adblock Lists")
             image: "image://theme/icon-l-attention"
             //image: "file://usr/share/themes/sailfish-default/silica/z1.75/icons-monochrome/icon-l-attention.png"
             itemPage: "SourcesPage.qml"
             menuItemSource: "components/SourcesMenuItem.qml"
         }
         ListElement {
-            name: "Cookies"
+            name: qsTr("Cookies")
             image: "image://theme/icon-l-transfer"
             itemPage: "CookiesPage.qml"
             menuItemSource: "components/CookiesMenuItem.qml"
         }
         ListElement {
-            name: "Documentation"
+            name: qsTr("Documentation")
             image: "image://theme/icon-l-document"
             itemPage: "DocsPage.qml"
             menuItemSource: "components/GeneralMenuItem.qml"
         }
         ListElement {
-            name: "Settings"
+            name: qsTr("Settings")
             image: "image://theme/icon-l-developer-mode"
             itemPage: "SettingsPage.qml"
             menuItemSource: "components/GeneralMenuItem.qml"

--- a/qml/pages/components/CookiesMenuItem.qml
+++ b/qml/pages/components/CookiesMenuItem.qml
@@ -31,7 +31,7 @@ BackgroundItem {
         }
         Label {
             x: Theme.paddingLarge
-            text: "Cookie Manager"
+            text: qsTr("Cookie Manager")
 
             color: delegate.highlighted ? Theme.highlightColor : Theme.primaryColor
             anchors.horizontalCenter: parent.horizontalCenter

--- a/qml/pages/components/SourcesMenuItem.qml
+++ b/qml/pages/components/SourcesMenuItem.qml
@@ -31,7 +31,7 @@ BackgroundItem {
         }
         Label {
             x: Theme.paddingLarge
-            text: "Adblock Lists"
+            text: qsTr("Adblock Lists")
             color: delegate.highlighted ? Theme.highlightColor : Theme.primaryColor
             anchors.horizontalCenter: parent.horizontalCenter
         }

--- a/translations/harbour-defender-sv.ts
+++ b/translations/harbour-defender-sv.ts
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>CookiesMenuItem</name>
+    <message>
+        <location filename="../qml/pages/components/CookiesMenuItem.qml" line="23"/>
+        <source>Cookies</source>
+        <translation>Cookies</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/components/CookiesMenuItem.qml" line="28"/>
+        <source>Domains</source>
+        <translation>Domäner</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesMenuItem.qml" line="34"/>
+        <source>Cookie Manager</source>
+        <translation>Cookie-hanterare</translation>
+    </message>
+</context>
+<context>
+    <name>CookiesPage</name>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="14"/>
+        <source>Search cookies</source>
+        <translation>Sök cookies</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="29"/>
+        <source>Unlock cookies</source>
+        <translation>Lås upp cookies</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="29"/>
+        <source>Lock cookies</source>
+        <translation>Lås cookies</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="31"/>
+        <source>Unlocking</source>
+        <translation>Låser upp</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="31"/>
+        <source>Locking</source>
+        <translation>Låser</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="40"/>
+        <source>Delete all blacklisted</source>
+        <translation>Ta bort alla svartlistade</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="56"/>
+        <source>Delete all not whitelisted</source>
+        <translation>Ta bort alla icke vitlistade</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="111"/>
+        <source>Remove</source>
+        <translation>Ta bort</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="115"/>
+        <source>Remove from Whitelist</source>
+        <translation>Ta bort från vitlistan</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="115"/>
+        <source>Add to Whitelist</source>
+        <translation>Lägg till i vitlistan</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="134"/>
+        <source>Remove from Blacklist</source>
+        <translation>Ta bort från svartlistan</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="134"/>
+        <source>Add to Blacklist</source>
+        <translation>Lägg till i svartlistan</translation>
+    </message>
+</context>
+<context>
+    <name>DocsPage</name>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="30"/>
+        <source>Warning</source>
+        <translation>Varning</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="35"/>
+        <source>The installation and use of this application is solely in the responsibility of the user. The developers/authors are not responsible for the content of ad blocking sources available from the application, therefore you need to be careful when enabling them.</source>
+        <translation>Installation och användning av denna applikation, sker på användarens ansvar. Programmets utvecklare ansvarar inte för innehållet i de blocklistor som finns tillgängliga i programmet, du bör därför vara försiktig när du aktiverar dem.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="41"/>
+        <source>Adblock Lists</source>
+        <translation>Blocklistor</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="44"/>
+        <source>How to add custom lists?</source>
+        <translation>Hur lägger man till anpassade listor?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="49"/>
+        <source>You can add custom lists by editing the file /etc/defender.conf as root (either using the command line or an appropriate editor). See other sections in the config file for inspiration. In the square brackets [] should be a unique id.</source>
+        <translation>Du kan lägga till anpassade listor genom att redigera filen /etc/defender.conf som root (antingen i Terminal eller med en lämplig textredigerare). Se andra avsnitt i konfigurationsfilen för inspiration. Inom hakparenteserna [] ska det finnas ett unikt ID.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="55"/>
+        <source>Why can&apos;t I add new sources from the app?</source>
+        <translation>Varför kan jag inte lägga till nya källor i appen?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="60"/>
+        <source>It would be a security threat to allow adding new sources as a normal user (with the current SailfishOS security situation), as any app would be able to add new sources and potentially compromise your device. Even with the default sources, you still make the leap of faith to trust a remote source. If you want to have a source added/removed to/from the defaults, contact the app developer and see if it can be available in the next version.</source>
+        <translation>Det skulle vara ett säkerhetshot att tillåta normalanvändare att lägga till nya blocklistkällor (under SailfishOS nuvarande säkerhetssituation), eftersom vilken app som helst skulle kunna lägga till nya källor och potentiellt skada ditt system. Även med programmets standardkällor, måste du lita på en fjärrbaserad källa. Om du vill lägga till/ta bort en blocklista i standardutbudet, kan du kontakta utvecklaren och fråga om ändringen kan ske i nästa programversion.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="66"/>
+        <source>How to add custom entries?</source>
+        <translation>Hur lägger man till anpassade poster?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="71"/>
+        <source>You can add your custom hosts entries by editing the file /etc/hosts.editable and treating it as a generic hosts file. Don&apos;t forget to choose &apos;Update Now&apos; in the app to see an immediate effect.</source>
+        <translation>Du kan lägga till anpassade hosts-poster genom att redigera filen &quot;/etc/hosts.editable&quot; och behandla den som en allmän hosts-fil. Glöm inte att trycka &quot;Uppdatera nu&quot; i appen, för omedelbar tillämpning.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="77"/>
+        <source>Why can&apos;t I add new entries from the app?</source>
+        <translation>Varför kan jag inte lägga till anpassade poster från appen?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="82"/>
+        <source>Again, it would be a security threat (see the answer above), therefore one needs to be root to add/modify hosts file entries.</source>
+        <translation>Återigen, det skulle innebära ett säkerhetshot (se ovanstående svar), därför måste man vara root för att lägga till/ändra hosts-filposter.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="88"/>
+        <source>Cookies</source>
+        <translation>Cookies</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="93"/>
+        <source>The cookie manager works by editing the -/.local/share/org.sailfishos/browser/.mozilla/ (for SFOS up to 3.4: -/.mozilla/mozembed/) cookies.sqlite database. In order to access/work with cookies the browser needs to be closed before opening the cookies section, else you might see an empty window. All changes need the browser to be closed/restarted in order to take effect.</source>
+        <translation>Cookie-hanterarens funktion är att redigera databasen $HOME/.local/share/org.sailfishos/browser/.mozilla/ (för SFOS upp till 3.4: $HOME/.mozilla/mozembed/) cookies.sqlite. För att få åtkomst till, och arbeta med cookies behöver webbläsaren stängas innan cookies-sektionen öppnas, annars kan du få se ett tomt fönster. Alla ändringar kräver att webbläsaren stängs/startas om för att träda i kraft.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="99"/>
+        <source>Cookie Locking</source>
+        <translation>Cookie-lås</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="104"/>
+        <source>Cookie locking works by making the cookie database read only, therefore its contents stay same between restarting the browser. The effect of this is cookies not being persistent over browser restarts.</source>
+        <translation>Cookie-låset skrivskyddar cookie-databasen, därför bevaras innehållet intakt, om webbläsaren startas om. Effekten av detta, är att cookies inte är beständiga mellan webbläsarsessioner.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsPage</name>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="19"/>
+        <source>Settings</source>
+        <translation>Inställningar</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="22"/>
+        <source>Clear Cookie Blacklist</source>
+        <translation>Rensa cookie-svartlistan</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="33"/>
+        <source>Clear Cookie Whitelist</source>
+        <translation>Rensa cookie-vitlistan</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="44"/>
+        <source>WLAN only</source>
+        <translation>Endast WLAN</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="45"/>
+        <source>Downloads adblock lists only if connected to WLAN (tested only on Jolla phones)</source>
+        <translation>Laddar ner blocklistor endast vid WLAN-anslutning (testad endast på Jolla-telefoner)</translation>
+    </message>
+</context>
+<context>
+    <name>SourceDetailPage</name>
+    <message>
+        <location filename="../qml/pages/SourceDetailPage.qml" line="15"/>
+        <source>Open hosts file URL</source>
+        <translation>Öppna hosts-filens URL</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourceDetailPage.qml" line="19"/>
+        <source>More information</source>
+        <translation>Mer information</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourceDetailPage.qml" line="43"/>
+        <source>Source</source>
+        <translation>Källa</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourceDetailPage.qml" line="47"/>
+        <source>License</source>
+        <translation>Licens</translation>
+    </message>
+</context>
+<context>
+    <name>SourcesMenuItem</name>
+    <message>
+        <location filename="../qml/pages/components/SourcesMenuItem.qml" line="23"/>
+        <source>Blocked</source>
+        <translation>Blockerat</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/components/SourcesMenuItem.qml" line="28"/>
+        <source>Lists</source>
+        <translation>Listor</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesMenuItem.qml" line="34"/>
+        <source>Adblock Lists</source>
+        <translation>Blocklistor</translation>
+    </message>
+</context>
+<context>
+    <name>SourcesPage</name>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="13"/>
+        <source>Disable all</source>
+        <translation>Avaktivera alla</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="21"/>
+        <source>Cancel/clear update loop</source>
+        <translation>Avbryt/Rensa uppdateringsloopen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="29"/>
+        <source>Show error log (just in case ;)</source>
+        <translation>Visa fel-logg (för säkerhets skull ;)</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="37"/>
+        <source>Restart Android support</source>
+        <translation>Starta om Android-tjänsten</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="45"/>
+        <source>Update now</source>
+        <translation>Uppdatera nu</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="56"/>
+        <source>Sources</source>
+        <translation>Källor</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="62"/>
+        <source>Updating...</source>
+        <translation>Uppdaterar...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="68"/>
+        <source>Update in progress. This may take a while, but you can safely close the application and the update will finish in the background.</source>
+        <translation>Uppdatering pågår. Detta kan ta en stund, men du kan utan problem stänga programmet och låta uppdateringen slutföras i bakgrunden.</translation>
+    </message>
+</context>
+<context>
+    <name>harbour-defender</name>
+    <message>
+        <location filename="../qml/harbour-defender.qml" line="13"/>
+        <source>Defender</source>
+        <translation>Defender</translation>
+    </message>
+</context>
+<context>
+    <name>WelcomePage</name>
+    <message>
+        <location filename="../qml/pages/WelcomePage.qml" line="40"/>
+        <source>Documentation</source>
+        <translation>Dokumentation</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/WelcomePage.qml" line="46"/>
+        <source>Settings</source>
+        <translation>Inställningar</translation>
+    </message>
+</context>
+</TS>

--- a/translations/harbour-defender.ts
+++ b/translations/harbour-defender.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="">
 <context>
     <name>CookiesMenuItem</name>
     <message>
@@ -13,9 +13,19 @@
         <source>Domains</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../qml/pages/CookiesMenuItem.qml" line="34"/>
+        <source>Cookie Manager</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CookiesPage</name>
+    <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="14"/>
+        <source>Search cookies</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../qml/pages/CookiesPage.qml" line="29"/>
         <source>Unlock cookies</source>
@@ -47,6 +57,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/CookiesPage.qml" line="111"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../qml/pages/CookiesPage.qml" line="115"/>
         <source>Remove from Whitelist</source>
         <translation type="unfinished"></translation>
@@ -70,72 +85,77 @@
 <context>
     <name>DocsPage</name>
     <message>
-        <location filename="../qml/pages/DocsPage.qml" line="19"/>
+        <location filename="../qml/pages/DocsPage.qml" line="30"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DocsPage.qml" line="24"/>
+        <location filename="../qml/pages/DocsPage.qml" line="35"/>
         <source>The installation and use of this application is solely in the responsibility of the user. The developers/authors are not responsible for the content of ad blocking sources available from the application, therefore you need to be careful when enabling them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DocsPage.qml" line="30"/>
+        <location filename="../qml/pages/DocsPage.qml" line="41"/>
         <source>Adblock Lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DocsPage.qml" line="33"/>
+        <location filename="../qml/pages/DocsPage.qml" line="44"/>
         <source>How to add custom lists?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DocsPage.qml" line="44"/>
-        <source>Why can&apos;t I add new sources from the app?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/pages/DocsPage.qml" line="49"/>
-        <source>It would be a security threat to allow adding new sources as a normal user (with the current SailfishOS security situation), as any app would be able to add new sources and potentially compromise your device. Even with the default sources, you still make the leap of faith to trust a remote source. If you want to have a source added/removed to/from the defaults, contact the app developer and see if it can be available in the next version.</source>
+        <source>You can add custom lists by editing the file /etc/defender.conf as root (either using the command line or an appropriate editor). See other sections in the config file for inspiration. In the square brackets [] should be a unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="55"/>
-        <source>How to add custom entries?</source>
+        <source>Why can&apos;t I add new sources from the app?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="60"/>
-        <source>You can add your custom hosts entries by editing the file /etc/hosts.editable and treating it as a generic hosts file. Don&apos;t forget to choose &apos;Update Now&apos; in the app to see an immediate effect.</source>
+        <source>It would be a security threat to allow adding new sources as a normal user (with the current SailfishOS security situation), as any app would be able to add new sources and potentially compromise your device. Even with the default sources, you still make the leap of faith to trust a remote source. If you want to have a source added/removed to/from the defaults, contact the app developer and see if it can be available in the next version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="66"/>
-        <source>Why can&apos;t I add new entries from the app?</source>
+        <source>How to add custom entries?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="71"/>
-        <source>Again, it would be a security threat (see the answer above), therefore one needs to be root to add/modify hosts file entries.</source>
+        <source>You can add your custom hosts entries by editing the file /etc/hosts.editable and treating it as a generic hosts file. Don&apos;t forget to choose &apos;Update Now&apos; in the app to see an immediate effect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="77"/>
-        <source>Cookies</source>
+        <source>Why can&apos;t I add new entries from the app?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="82"/>
-        <source>The cookie manager works by editing the /home/nemo/.mozilla/mozembed/cookies.sqlite database. All changes need the browser to be restarted in order to take effect.</source>
+        <source>Again, it would be a security threat (see the answer above), therefore one needs to be root to add/modify hosts file entries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="88"/>
-        <source>Cookie Locking</source>
+        <source>Cookies</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DocsPage.qml" line="93"/>
+        <source>The cookie manager works by editing the -/.local/share/org.sailfishos/browser/.mozilla/ (for SFOS up to 3.4: -/.mozilla/mozembed/) cookies.sqlite database. In order to access/work with cookies the browser needs to be closed before opening the cookies section, else you might see an empty window. All changes need the browser to be closed/restarted in order to take effect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="99"/>
+        <source>Cookie Locking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DocsPage.qml" line="104"/>
         <source>Cookie locking works by making the cookie database read only, therefore its contents stay same between restarting the browser. The effect of this is cookies not being persistent over browser restarts.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -203,31 +223,51 @@
         <source>Lists</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../qml/pages/SourcesMenuItem.qml" line="34"/>
+        <source>Adblock Lists</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SourcesPage</name>
     <message>
         <location filename="../qml/pages/SourcesPage.qml" line="13"/>
-        <source>Disable</source>
+        <source>Disable all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/SourcesPage.qml" line="21"/>
+        <source>Cancel/clear update loop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="29"/>
+        <source>Show error log (just in case ;)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="37"/>
+        <source>Restart Android support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SourcesPage.qml" line="45"/>
         <source>Update now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SourcesPage.qml" line="32"/>
+        <location filename="../qml/pages/SourcesPage.qml" line="56"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SourcesPage.qml" line="38"/>
+        <location filename="../qml/pages/SourcesPage.qml" line="62"/>
         <source>Updating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SourcesPage.qml" line="44"/>
+        <location filename="../qml/pages/SourcesPage.qml" line="68"/>
         <source>Update in progress. This may take a while, but you can safely close the application and the update will finish in the background.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -237,6 +277,19 @@
     <message>
         <location filename="../qml/harbour-defender.qml" line="13"/>
         <source>Defender</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WelcomePage</name>
+    <message>
+        <location filename="../qml/pages/WelcomePage.qml" line="40"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/WelcomePage.qml" line="46"/>
+        <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Fixed working translations and add Swedish.
Sorry, I don't know how to fix harbour-defender-de.ts, and there will still be some untranslatable error messages/messages. Hope to fix that later. However user interface translation works fine, it's just those damn messages I didn't figure out... if there even is any. I've never seen one on screen, but only in code.  ;)